### PR TITLE
feat: Add typing animation to homepage header

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,58 @@
+import { useState, useEffect } from 'react';
 import Layout from '../components/Layout';
 
+const FULL_TEXT = "Building for something greater.";
+const TYPING_SPEED = 120;
+const DELETING_SPEED = 70;
+const PAUSE_DURATION = 1500; // 1.5 seconds
+
 export default function Home() {
+  const [displayedText, setDisplayedText] = useState('');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+
+  useEffect(() => {
+    if (isPaused) {
+      const timer = setTimeout(() => {
+        setIsPaused(false);
+        // If it was paused after typing, start deleting
+        if (!isDeleting && currentIndex === FULL_TEXT.length) {
+          setIsDeleting(true);
+        }
+        // If it was paused after deleting, start typing
+        else if (isDeleting && currentIndex === 0) {
+          setIsDeleting(false);
+        }
+      }, PAUSE_DURATION);
+      return () => clearTimeout(timer);
+    }
+
+    const currentSpeed = isDeleting ? DELETING_SPEED : TYPING_SPEED;
+    const timer = setTimeout(() => {
+      if (!isDeleting) { // Typing
+        if (currentIndex < FULL_TEXT.length) {
+          setDisplayedText((prev) => prev + FULL_TEXT[currentIndex]);
+          setCurrentIndex((prev) => prev + 1);
+        } else { // Finished typing
+          setIsPaused(true);
+        }
+      } else { // Deleting
+        if (currentIndex > 0) {
+          setDisplayedText((prev) => prev.substring(0, prev.length - 1));
+          setCurrentIndex((prev) => prev - 1);
+        } else { // Finished deleting
+          setIsPaused(true);
+        }
+      }
+    }, currentSpeed);
+
+    return () => clearTimeout(timer);
+  }, [displayedText, currentIndex, isDeleting, isPaused]);
+
   return (
     <Layout>
-      <h1 className="text-3xl font-bold mb-4">Building for something greater.</h1>
+      <h1 className="text-3xl font-bold mb-4 typing-effect">{displayedText}</h1>
       <p className="text-lg mb-6">I’m Sung-Yun Cho, a builder at the intersection of philosophy, technology, and execution.</p>
       <blockquote className="italic text-gray-600 dark:text-gray-400">
         “Perfection is achieved not when there is nothing more to add, but when there is nothing left to take away.”

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,6 +16,25 @@ body {
   }
 }
 
+.typing-effect::after {
+  content: '|';
+  animation: blink 1s step-end infinite;
+  /* Ensure the cursor color matches the text color, 
+     or set a specific color. currentColor should work with dark/light mode. */
+  color: currentColor; 
+  /* Adjust margin if needed to position the cursor correctly */
+  margin-left: 0.1em; 
+}
+
+@keyframes blink {
+  from, to {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
 @layer base {
   h1, h2, h3 {
     @apply font-['Space_Grotesk'];


### PR DESCRIPTION
This commit introduces a typing animation effect to the main header ("Building for something greater.") on the homepage (`pages/index.tsx`).

Key changes:
- Implemented a React-based typing animation that types out the full text, pauses, deletes the text, pauses again, and then repeats the cycle continuously. This is handled within the `Home` component using `useState` and `useEffect` hooks.
- Added a CSS blinking cursor effect using a `::after` pseudo-element on the animated `<h1>` tag. The styles are defined in `styles/globals.css` and applied via a new class `typing-effect`.
- Ensured the project builds successfully with these changes.

The animation enhances the visual appeal of the homepage header and starts automatically on page load.